### PR TITLE
Remove redundant Maven build steps and fix module paths in pom.xml

### DIFF
--- a/.github/workflows/uservice-timeentries.yml
+++ b/.github/workflows/uservice-timeentries.yml
@@ -53,13 +53,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       
-      - name: Build gRpc API (Maven)
-        run: mvn -ntp install
-        working-directory: api/client-java
-      - name: Build base package (Maven)
-        run: mvn -ntp install
-        working-directory: libs-java
-
       - name: Build Timeentries (Maven)
         run: |
           # download latest version of applicationinsights to folder expected to be included into target image

--- a/.github/workflows/uservice-webapi.yml
+++ b/.github/workflows/uservice-webapi.yml
@@ -53,13 +53,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       
-      - name: Build with Maven gRpc API
-        run: mvn -ntp install
-        working-directory: api/client-java
-      - name: Build with Maven base package
-        run: mvn -ntp install
-        working-directory: libs-java
-
       - name: Build with Maven Webapi
         run: |
           # download latest version of applicationinsights to folder expected to be included into target image

--- a/uservice-timeentries/pom.xml
+++ b/uservice-timeentries/pom.xml
@@ -12,6 +12,8 @@
     <module>initdb-test</module>
     <module>initdb-host</module>
     <module>report-aggregate</module>
+    <module>../api/client-java</module>
+    <module>../libs-java</module>
   </modules>
 
   <properties>

--- a/uservice-webapi/pom.xml
+++ b/uservice-webapi/pom.xml
@@ -10,6 +10,8 @@
     <module>gql-test</module>
     <module>gql-model</module>
     <module>base-pom</module>
+    <module>../api/client-java</module>
+    <module>../libs-java</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Eliminate unnecessary Maven build steps from the CI workflow and ensure that module paths are correctly defined in the pom.xml file.