### PR TITLE
Implement PDF generation endpoint for Report1

### DIFF
--- a/fun_report1/pyproject.toml
+++ b/fun_report1/pyproject.toml
@@ -35,3 +35,7 @@ warn_unreachable = true
 module = ["azure.functions.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["reportlab.*"]
+ignore_missing_imports = true
+

--- a/fun_report1/requirements.txt
+++ b/fun_report1/requirements.txt
@@ -3,3 +3,4 @@ fastapi>=0.115,<1.0
 uvicorn[standard]>=0.32,<1.0
 pydantic>=2.9,<3.0
 pydantic-settings>=2.6,<3.0
+reportlab>=4.0,<5.0

--- a/fun_report1/src/app.py
+++ b/fun_report1/src/app.py
@@ -2,23 +2,20 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-
 from fastapi import FastAPI
+from fastapi.responses import Response
 
 from src.models_generated import (
     HealthResponse,
-    ReportItem,
-    ReportResponse,
-    ReportSummary,
     Status,
 )
+from src.models_report1 import ReportRequest, ReportRequests
 
 # FastAPI application instance
 fastapi_app = FastAPI(
     title="Fun Report1 API",
     description=(
-        "Azure Function app providing health checks and sample report generation"
+        "Azure Function app providing health checks and report generation"
     ),
     version="1.0.0",
     openapi_url="/api/openapi.json",
@@ -39,63 +36,51 @@ async def health() -> HealthResponse:
     return HealthResponse(status=Status.ok, service="app_raport1")
 
 
-@fastapi_app.get(
-    "/api/report",
-    response_model=ReportResponse,
+@fastapi_app.post(
+    "/api/report1/zip",
     tags=["Reports"],
-    summary="Generate sample report",
-    operation_id="getReport",
+    summary="Generate Raport miesięczny - załączniki do faktur",
+    operation_id="generateReport1Zip",
+    response_class=Response,
+    responses={
+        200: {
+            "content": {"application/zip": {}},
+            "description": "ZIP archive with PDF attachments",
+        }
+    },
 )
-async def report() -> ReportResponse:
-    """Return deterministic sample report JSON for manual verification."""
-    summary = ReportSummary(
-        hours=40.0,
-        billableAmount=5000.0,
-        entries=5,
+async def generate_report1_zip(request: ReportRequests) -> Response:
+    """Generate ZIP archive with PDF invoice attachments for all customers."""
+    from src.zip_generator import generate_zip
+
+    zip_bytes = generate_zip(request)
+    return Response(
+        content=zip_bytes,
+        media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=report1.zip"},
     )
 
-    items = [
-        ReportItem(
-            day=datetime(2026, 1, 5, tzinfo=UTC).date(),
-            project="Internal",
-            hours=8.0,
-            rate=125.0,
-            amount=1000.0,
-        ),
-        ReportItem(
-            day=datetime(2026, 1, 6, tzinfo=UTC).date(),
-            project="Internal",
-            hours=8.0,
-            rate=125.0,
-            amount=1000.0,
-        ),
-        ReportItem(
-            day=datetime(2026, 1, 7, tzinfo=UTC).date(),
-            project="Internal",
-            hours=8.0,
-            rate=125.0,
-            amount=1000.0,
-        ),
-        ReportItem(
-            day=datetime(2026, 1, 8, tzinfo=UTC).date(),
-            project="Internal",
-            hours=8.0,
-            rate=125.0,
-            amount=1000.0,
-        ),
-        ReportItem(
-            day=datetime(2026, 1, 9, tzinfo=UTC).date(),
-            project="Internal",
-            hours=8.0,
-            rate=125.0,
-            amount=1000.0,
-        ),
-    ]
 
-    return ReportResponse(
-        reportId="sample-001",
-        generatedAt=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
-        currency="PLN",
-        summary=summary,
-        items=items,
+@fastapi_app.post(
+    "/api/report1/pdf",
+    tags=["Reports"],
+    summary="Generate single PDF attachment for one customer",
+    operation_id="generateReport1Pdf",
+    response_class=Response,
+    responses={
+        200: {
+            "content": {"application/pdf": {}},
+            "description": "Single PDF attachment for the provided customer",
+        }
+    },
+)
+async def generate_report1_pdf(request: ReportRequest) -> Response:
+    """Generate a single customer PDF using the same renderer as ZIP generation."""
+    from src.pdf_generator import generate_pdf
+
+    pdf_bytes = generate_pdf(request)
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": "attachment; filename=report1.pdf"},
     )

--- a/fun_report1/src/models_report1.py
+++ b/fun_report1/src/models_report1.py
@@ -1,0 +1,132 @@
+"""Pydantic v2 models for the report1 input data.
+
+These models mirror the protobuf definitions in reports1.proto and are used
+as FastAPI request bodies for the report generation endpoints.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ActivityDate(BaseModel):
+    """A calendar date composed of year, month and day components."""
+
+    year: int = Field(..., description="Full calendar year, e.g. 2024")
+    month: int = Field(..., ge=1, le=12, description="Month of year (1–12)")
+    day: int = Field(..., ge=1, le=31, description="Day of month (1–31)")
+
+
+class ActivityDetails(BaseModel):
+    """A single service activity performed for a customer."""
+
+    description: str = Field(..., description="Human-readable description of the work")
+    who: str = Field(..., description="Serviceman / technician name")
+    when: ActivityDate | None = Field(None, description="Date the work was performed")
+    how_long_in_mins: int = Field(0, ge=0, description="Duration in minutes; 0 means untimed")
+    how_far_in_kms: int = Field(0, ge=0, description="Distance travelled in kilometres")
+
+
+class CustomerDetails(BaseModel):
+    """Identifying and address information for a customer."""
+
+    customer_id: str = Field(..., description="Unique customer identifier")
+    customer_name: str = Field(..., description="Display name of the customer")
+    customer_city: str = Field(..., description="City where the customer is located")
+    customer_address: str = Field(..., description="Street address of the customer")
+
+
+class ReportRequest(BaseModel):
+    """All data required to produce one customer's PDF attachment."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "customer": {
+                    "customer_id": "cust-001",
+                    "customer_name": "Zaklad Instalacji Sanitarnych Kowalski",
+                    "customer_city": "Warszawa",
+                    "customer_address": "ul. Prosta 12/4",
+                },
+                "activities": [
+                    {
+                        "description": "Przeglad i naprawa pompy",
+                        "who": "Marek Zolc",
+                        "when": {"year": 2026, "month": 7, "day": 10},
+                        "how_long_in_mins": 135,
+                        "how_far_in_kms": 24,
+                    },
+                    {
+                        "description": "Dostawa czesci zamiennych",
+                        "who": "Anna Nowak",
+                        "when": {"year": 2026, "month": 7, "day": 11},
+                        "how_long_in_mins": 0,
+                        "how_far_in_kms": 18,
+                    },
+                ],
+            }
+        }
+    )
+
+    customer: CustomerDetails = Field(..., description="Customer identification details")
+    activities: list[ActivityDetails] = Field(
+        default_factory=list, description="List of service activities for this customer"
+    )
+
+
+class ReportRequests(BaseModel):
+    """Collection of per-customer report requests bundled into one ZIP job."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "items": [
+                    {
+                        "customer": {
+                            "customer_id": "cust-001",
+                            "customer_name": "Zaklad Instalacji Sanitarnych Kowalski",
+                            "customer_city": "Warszawa",
+                            "customer_address": "ul. Prosta 12/4",
+                        },
+                        "activities": [
+                            {
+                                "description": "Przeglad i naprawa pompy",
+                                "who": "Marek Zolc",
+                                "when": {"year": 2026, "month": 7, "day": 10},
+                                "how_long_in_mins": 135,
+                                "how_far_in_kms": 24,
+                            },
+                            {
+                                "description": "Dostawa czesci zamiennych",
+                                "who": "Anna Nowak",
+                                "when": {"year": 2026, "month": 7, "day": 11},
+                                "how_long_in_mins": 0,
+                                "how_far_in_kms": 18,
+                            },
+                        ],
+                    },
+                    {
+                        "customer": {
+                            "customer_id": "cust-002",
+                            "customer_name": "Biuro Rachunkowe Delta",
+                            "customer_city": "Lodz",
+                            "customer_address": "ul. Zielona 8",
+                        },
+                        "activities": [
+                            {
+                                "description": "Konfiguracja sieci biurowej",
+                                "who": "Piotr Wisniewski",
+                                "when": {"year": 2026, "month": 7, "day": 12},
+                                "how_long_in_mins": 90,
+                                "how_far_in_kms": 12,
+                            }
+                        ],
+                    },
+                ]
+            }
+        }
+    )
+
+    items: list[ReportRequest] = Field(
+        default_factory=list, description="One entry per customer to include in the ZIP"
+    )

--- a/fun_report1/src/pdf_generator.py
+++ b/fun_report1/src/pdf_generator.py
@@ -1,0 +1,320 @@
+"""PDF generation for the 'Raport miesięczny - załączniki do faktur' report.
+
+Produces a single-customer PDF that matches the layout of the Java reference
+implementation (ReportResults.java):
+
+  - Header:  CustomerName (bold) + ", " + City + " ul. " + Address (regular)
+  - Table 1: timed activities (howLongInMins > 0) with column headers and a
+             bold summary row (no border)
+  - Table 2: untimed / extra-service activities (howLongInMins == 0) preceded
+             by a bold "USŁUGI DODATKOWE" title row and a bold summary row
+             (no border)
+
+Column widths are proportionally scaled from the Java reference (225 units
+total) to fit a 450 pt content width on an A4 portrait page.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.platypus import (
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+from reportlab.platypus.flowables import Flowable
+
+from src.models_report1 import ActivityDetails, ReportRequest
+
+# ---------------------------------------------------------------------------
+# Layout constants
+# ---------------------------------------------------------------------------
+
+_PAGE_WIDTH, _PAGE_HEIGHT = A4
+_MARGIN = 36  # 0.5 inch margins on each side (in points)
+_CONTENT_WIDTH = _PAGE_WIDTH - 2 * _MARGIN  # ~523 pt for A4
+
+# Java reference column widths (sum = 225) → scaled to _CONTENT_WIDTH
+_JAVA_COLS = [50, 25, 120, 15, 15]
+_JAVA_TOTAL = sum(_JAVA_COLS)
+_COL_WIDTHS = [w * _CONTENT_WIDTH / _JAVA_TOTAL for w in _JAVA_COLS]
+
+_BASE_FONT_SIZE = 10
+_SERVICEMAN_FONT_SIZE = 6  # base - 4 as per Java reference
+
+_FONT_REGULAR = "DejaVuSans"
+_FONT_BOLD = "DejaVuSans-Bold"
+_FONT_REGULAR_PATH = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+_FONT_BOLD_PATH = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
+
+_SPACER_HEIGHT = 12  # points
+
+
+def _ensure_fonts_registered() -> None:
+    """Register Unicode-capable fonts used in PDF rendering."""
+    registered_fonts = set(pdfmetrics.getRegisteredFontNames())
+    if _FONT_REGULAR not in registered_fonts:
+        pdfmetrics.registerFont(TTFont(_FONT_REGULAR, str(_FONT_REGULAR_PATH)))
+    if _FONT_BOLD not in registered_fonts:
+        pdfmetrics.registerFont(TTFont(_FONT_BOLD, str(_FONT_BOLD_PATH)))
+
+# ---------------------------------------------------------------------------
+# Style helpers
+# ---------------------------------------------------------------------------
+
+_STYLES = getSampleStyleSheet()
+
+_HEADER_BOLD = ParagraphStyle(
+    "HeaderBold",
+    parent=_STYLES["Normal"],
+    fontName=_FONT_BOLD,
+    fontSize=_BASE_FONT_SIZE,
+    leading=14,
+)
+
+_HEADER_NORMAL = ParagraphStyle(
+    "HeaderNormal",
+    parent=_STYLES["Normal"],
+    fontName=_FONT_REGULAR,
+    fontSize=_BASE_FONT_SIZE,
+    leading=14,
+)
+
+# Table cell styles
+_CELL_NORMAL = ParagraphStyle(
+    "CellNormal",
+    parent=_STYLES["Normal"],
+    fontName=_FONT_REGULAR,
+    fontSize=_BASE_FONT_SIZE,
+)
+
+_CELL_BOLD = ParagraphStyle(
+    "CellBold",
+    parent=_STYLES["Normal"],
+    fontName=_FONT_BOLD,
+    fontSize=_BASE_FONT_SIZE,
+)
+
+_CELL_SERVICEMAN = ParagraphStyle(
+    "CellServiceman",
+    parent=_STYLES["Normal"],
+    fontName=_FONT_REGULAR,
+    fontSize=_SERVICEMAN_FONT_SIZE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_duration(mins: int) -> str:
+    """Format minutes as 'H:MM' (e.g. 90 → '1:30')."""
+    hours = mins // 60
+    remaining = mins % 60
+    return f"{hours}:{remaining:02d}"
+
+
+def _format_date(activity: ActivityDetails) -> str:
+    """Format ActivityDate as 'dd-MM-yyyy', or empty string when absent."""
+    if activity.when is None:
+        return ""
+    d = activity.when
+    return f"{d.day:02d}-{d.month:02d}-{d.year:04d}"
+
+
+# ---------------------------------------------------------------------------
+# Table builders
+# ---------------------------------------------------------------------------
+
+_COL_HEADERS = ["Serwisant", "Dzień", "Praca wykonana", "Czas", "KM"]
+type StyleCommand = tuple[Any, ...]
+
+# TableStyle commands shared by both data tables
+_GRID_STYLE: list[StyleCommand] = [
+    ("FONTNAME", (0, 0), (-1, -1), _FONT_REGULAR),
+    ("FONTSIZE", (0, 0), (-1, -1), _BASE_FONT_SIZE),
+    ("FONTNAME", (0, 0), (0, -1), _FONT_REGULAR),
+    ("FONTSIZE", (0, 0), (0, -1), _SERVICEMAN_FONT_SIZE),
+    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+]
+
+
+def _header_row_style(row: int) -> list[StyleCommand]:
+    """Return TableStyle commands that add a full grid border to *row*."""
+    return [
+        ("FONTNAME", (0, row), (-1, row), _FONT_BOLD),
+        ("FONTSIZE", (0, row), (-1, row), _BASE_FONT_SIZE),
+        ("BOX", (0, row), (-1, row), 0.5, "black"),
+        ("INNERGRID", (0, row), (-1, row), 0.5, "black"),
+    ]
+
+
+def _data_row_style(row: int) -> list[StyleCommand]:
+    """Return TableStyle commands that add a full grid border to a data *row*."""
+    return [
+        ("BOX", (0, row), (-1, row), 0.5, "black"),
+        ("INNERGRID", (0, row), (-1, row), 0.5, "black"),
+    ]
+
+
+def _summary_row_style(row: int) -> list[StyleCommand]:
+    """Return TableStyle commands for a bold, border-free summary *row*."""
+    return [
+        ("FONTNAME", (0, row), (-1, row), _FONT_BOLD),
+        ("FONTSIZE", (0, row), (-1, row), _BASE_FONT_SIZE),
+        # Explicitly no box/innergrid → no border
+    ]
+
+
+def _build_timed_table(timed: list[ActivityDetails]) -> Table:
+    """Build the table for timed activities (howLongInMins > 0).
+
+    Includes a column-header row, one data row per activity, and a bold
+    summary row without borders.
+    """
+    rows: list[list[str]] = [_COL_HEADERS]
+    total_mins = 0
+    total_km = 0
+
+    for act in timed:
+        rows.append(
+            [
+                act.who,
+                _format_date(act),
+                act.description,
+                _format_duration(act.how_long_in_mins),
+                str(act.how_far_in_kms),
+            ]
+        )
+        total_mins += act.how_long_in_mins
+        total_km += act.how_far_in_kms
+
+    # Summary row (bold, no border)
+    rows.append(["", "", "Suma", _format_duration(total_mins), str(total_km)])
+
+    style_cmds: list[StyleCommand] = list(_GRID_STYLE)
+    style_cmds += _header_row_style(0)
+    for idx in range(1, len(rows) - 1):
+        style_cmds += _data_row_style(idx)
+    style_cmds += _summary_row_style(len(rows) - 1)
+
+    return Table(rows, colWidths=_COL_WIDTHS, style=TableStyle(style_cmds))
+
+
+def _build_untimed_table(untimed: list[ActivityDetails]) -> Table:
+    """Build the table for untimed / extra-service activities (howLongInMins == 0).
+
+    Includes a full-width title row ("USŁUGI DODATKOWE"), a column-header row,
+    one data row per activity, and a bold summary row without borders.
+    """
+    # Row 0: full-width title (span all columns, bold, no border)
+    title_row: list[str] = ["USŁUGI DODATKOWE", "", "", "", ""]
+
+    rows: list[list[str]] = [title_row, _COL_HEADERS]
+    total_km = 0
+
+    for act in untimed:
+        rows.append(
+            [
+                act.who,
+                _format_date(act),
+                act.description,
+                "0:00",
+                str(act.how_far_in_kms),
+            ]
+        )
+        total_km += act.how_far_in_kms
+
+    rows.append(["", "", "Suma", "0:00", str(total_km)])
+
+    style_cmds: list[StyleCommand] = list(_GRID_STYLE)
+
+    # Title row: bold, spanning all columns, no border
+    style_cmds += [
+        ("FONTNAME", (0, 0), (-1, 0), _FONT_BOLD),
+        ("FONTSIZE", (0, 0), (-1, 0), _BASE_FONT_SIZE),
+        ("SPAN", (0, 0), (-1, 0)),
+    ]
+
+    # Column header row (row 1)
+    style_cmds += _header_row_style(1)
+
+    # Data rows (rows 2 … len-2)
+    for idx in range(2, len(rows) - 1):
+        style_cmds += _data_row_style(idx)
+
+    # Summary row
+    style_cmds += _summary_row_style(len(rows) - 1)
+
+    return Table(rows, colWidths=_COL_WIDTHS, style=TableStyle(style_cmds))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_pdf(request: ReportRequest) -> bytes:
+    """Generate a PDF for a single customer matching the Java reference layout.
+
+    Parameters
+    ----------
+    request:
+        Per-customer data containing customer details and activity list.
+
+    Returns
+    -------
+    bytes
+        Raw PDF bytes ready to be written to a file or HTTP response.
+    """
+    _ensure_fonts_registered()
+
+    buffer = BytesIO()
+
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        leftMargin=_MARGIN,
+        rightMargin=_MARGIN,
+        topMargin=_MARGIN,
+        bottomMargin=_MARGIN,
+    )
+
+    # ------------------------------------------------------------------
+    # Split activities into timed and untimed
+    # ------------------------------------------------------------------
+    timed = [a for a in request.activities if a.how_long_in_mins != 0]
+    untimed = [a for a in request.activities if a.how_long_in_mins == 0]
+
+    # ------------------------------------------------------------------
+    # Customer header paragraph:
+    #   "<CustomerName>" (bold) + ", <City> ul. <Address>" (regular)
+    # ------------------------------------------------------------------
+    cust = request.customer
+    header_text = (
+        f'<b>{cust.customer_name}</b>'
+        f', {cust.customer_city} ul. {cust.customer_address}'
+    )
+    header_para = Paragraph(header_text, _HEADER_NORMAL)
+
+    story: list[Flowable] = [
+        header_para,
+        Spacer(1, _SPACER_HEIGHT),
+        _build_timed_table(timed),
+        Spacer(1, _SPACER_HEIGHT),
+        _build_untimed_table(untimed),
+        Spacer(1, _SPACER_HEIGHT),
+    ]
+
+    doc.build(story)
+    return buffer.getvalue()

--- a/fun_report1/src/zip_generator.py
+++ b/fun_report1/src/zip_generator.py
@@ -1,0 +1,44 @@
+"""ZIP archive generator for the 'Raport miesięczny - załączniki do faktur' report.
+
+Iterates over a collection of per-customer ReportRequest objects, generates
+one PDF per customer via pdf_generator.generate_pdf, and bundles them into
+an in-memory ZIP archive.
+
+Filename convention (mirrors Java Report1QueryPack.java):
+    "{index:03d}-{customer_name}.pdf"
+where index is 1-based and any "/" in customer_name is replaced with "_".
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+from src.models_report1 import ReportRequests
+from src.pdf_generator import generate_pdf
+
+
+def generate_zip(requests: ReportRequests) -> bytes:
+    """Generate a ZIP archive containing one PDF per customer.
+
+    Parameters
+    ----------
+    requests:
+        Collection of per-customer report requests.
+
+    Returns
+    -------
+    bytes
+        Raw ZIP bytes suitable for writing to a file or an HTTP response.
+    """
+    buffer = io.BytesIO()
+
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for index, request in enumerate(requests.items, start=1):
+            pdf_bytes = generate_pdf(request)
+            # Sanitise customer name: replace slashes to keep the filename valid
+            safe_name = request.customer.customer_name.replace("/", "_")
+            filename = f"{index:03d}-{safe_name}.pdf"
+            zf.writestr(filename, pdf_bytes)
+
+    return buffer.getvalue()

--- a/fun_report1/tests/test_function_app.py
+++ b/fun_report1/tests/test_function_app.py
@@ -6,7 +6,9 @@ response schemas, and contract compliance with OpenAPI specification.
 
 from __future__ import annotations
 
-from datetime import datetime
+import io
+import re
+import zipfile
 
 from fastapi.testclient import TestClient
 
@@ -37,74 +39,92 @@ def test_health_endpoint_schema_compliance() -> None:
     assert isinstance(payload["service"], str)
 
 
-def test_report_endpoint_success() -> None:
-    """Report endpoint returns expected top-level structure."""
-    response = client.get("/api/report")
+def test_generate_report1_zip_endpoint() -> None:
+    """POST /api/report1/zip returns a valid ZIP archive with application/zip content-type."""
+    payload = {
+        "items": [
+            {
+                "customer": {
+                    "customer_id": "cust-001",
+                    "customer_name": "Test Firma",
+                    "customer_city": "Warszawa",
+                    "customer_address": "Testowa 1",
+                },
+                "activities": [
+                    {
+                        "description": "Naprawa serwera",
+                        "who": "Jan Kowalski",
+                        "when": {"year": 2024, "month": 6, "day": 15},
+                        "how_long_in_mins": 90,
+                        "how_far_in_kms": 15,
+                    },
+                    {
+                        "description": "Konsultacja",
+                        "who": "Anna Nowak",
+                        "when": {"year": 2024, "month": 6, "day": 16},
+                        "how_long_in_mins": 0,
+                        "how_far_in_kms": 5,
+                    },
+                ],
+            }
+        ]
+    }
+
+    response = client.post("/api/report1/zip", json=payload)
 
     assert response.status_code == 200
-    payload = response.json()
-    assert payload["reportId"] == "sample-001"
-    assert payload["currency"] == "PLN"
-    assert payload["summary"]["entries"] == 5
-    assert len(payload["items"]) == 5
+    assert "application/zip" in response.headers["content-type"]
+    assert response.content[:2] == b"PK", "Response body must be a ZIP archive"
 
 
-def test_report_content_is_deterministic() -> None:
-    """Report payload stays deterministic across repeated calls."""
-    first_response = client.get("/api/report")
-    second_response = client.get("/api/report")
+def test_generate_report1_pdf_endpoint_matches_pdf_inside_zip() -> None:
+    """POST /api/report1/pdf returns the same PDF bytes as the ZIP endpoint for one customer."""
+    single_customer_payload = {
+        "customer": {
+            "customer_id": "cust-001",
+            "customer_name": "Test Firma",
+            "customer_city": "Warszawa",
+            "customer_address": "Testowa 1",
+        },
+        "activities": [
+            {
+                "description": "Naprawa serwera",
+                "who": "Jan Kowalski",
+                "when": {"year": 2024, "month": 6, "day": 15},
+                "how_long_in_mins": 90,
+                "how_far_in_kms": 15,
+            },
+            {
+                "description": "Konsultacja",
+                "who": "Anna Nowak",
+                "when": {"year": 2024, "month": 6, "day": 16},
+                "how_long_in_mins": 0,
+                "how_far_in_kms": 5,
+            },
+        ],
+    }
 
-    first_payload = first_response.json()
-    second_payload = second_response.json()
+    pdf_response = client.post("/api/report1/pdf", json=single_customer_payload)
+    assert pdf_response.status_code == 200
+    assert "application/pdf" in pdf_response.headers["content-type"]
+    assert pdf_response.content.startswith(b"%PDF-")
 
-    assert first_payload == second_payload
-    assert first_payload["generatedAt"] == "2026-01-01T00:00:00Z"
-    assert sum(item["amount"] for item in first_payload["items"]) == first_payload[
-        "summary"
-    ]["billableAmount"]
+    zip_response = client.post(
+        "/api/report1/zip", json={"items": [single_customer_payload]}
+    )
+    assert zip_response.status_code == 200
+    assert "application/zip" in zip_response.headers["content-type"]
 
+    with zipfile.ZipFile(io.BytesIO(zip_response.content), mode="r") as zf:
+        names = zf.namelist()
+        assert len(names) == 1
+        zipped_pdf = zf.read(names[0])
 
-def test_report_schema_compliance() -> None:
-    """Report endpoint response complies with OpenAPI schema."""
-    response = client.get("/api/report")
-
-    payload = response.json()
-
-    # Validate top-level fields
-    assert "reportId" in payload
-    assert "generatedAt" in payload
-    assert "currency" in payload
-    assert "summary" in payload
-    assert "items" in payload
-
-    # Validate currency pattern (3 uppercase letters)
-    assert len(payload["currency"]) == 3
-    assert payload["currency"].isupper()
-
-    # Validate timestamp format (ISO 8601)
-    datetime.fromisoformat(payload["generatedAt"].replace("Z", "+00:00"))
-
-    # Validate summary structure
-    summary = payload["summary"]
-    assert "hours" in summary
-    assert "billableAmount" in summary
-    assert "entries" in summary
-    assert summary["hours"] >= 0
-    assert summary["billableAmount"] >= 0
-    assert summary["entries"] >= 0
-
-    # Validate items array
-    items = payload["items"]
-    assert isinstance(items, list)
-    for item in items:
-        assert "day" in item
-        assert "project" in item
-        assert "hours" in item
-        assert "rate" in item
-        assert "amount" in item
-        assert item["hours"] >= 0
-        assert item["rate"] >= 0
-        assert item["amount"] >= 0
+    # ReportLab embeds a per-document trailer ID; normalize it before comparison.
+    id_pattern = rb"/ID\s*\[\s*<[^>]+>\s*<[^>]+>\s*\]"
+    normalized_pdf_response = re.sub(id_pattern, b"/ID [<fixed><fixed>]", pdf_response.content)
+    normalized_zipped_pdf = re.sub(id_pattern, b"/ID [<fixed><fixed>]", zipped_pdf)
+    assert normalized_pdf_response == normalized_zipped_pdf
 
 
 def test_openapi_docs_available() -> None:
@@ -116,7 +136,7 @@ def test_openapi_docs_available() -> None:
     assert "openapi" in openapi_spec
     assert "paths" in openapi_spec
     assert "/api/health" in openapi_spec["paths"]
-    assert "/api/report" in openapi_spec["paths"]
+    assert "/api/report1/pdf" in openapi_spec["paths"]
 
     # Test Swagger UI
     docs_response = client.get("/api/docs")

--- a/fun_report1/tests/test_pdf_generator.py
+++ b/fun_report1/tests/test_pdf_generator.py
@@ -1,0 +1,160 @@
+"""Unit tests for pdf_generator.generate_pdf.
+
+All tests are self-contained: they build in-memory ReportRequest objects,
+call generate_pdf, and verify the returned bytes without touching the file
+system or any external services.
+
+PDF text content is checked by decompressing the content streams embedded in
+the PDF.  ReportLab applies ASCII85Decode + FlateDecode by default, so each
+stream is ASCII85-decoded and then zlib-decompressed.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import zlib
+
+from src.models_report1 import ActivityDate, ActivityDetails, CustomerDetails, ReportRequest
+from src.pdf_generator import generate_pdf
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_customer(name: str = "Test Firma") -> CustomerDetails:
+    """Return a minimal CustomerDetails instance."""
+    return CustomerDetails(
+        customer_id="cust-001",
+        customer_name=name,
+        customer_city="Warszawa",
+        customer_address="Testowa 1",
+    )
+
+
+def _make_timed_activity(mins: int = 90, kms: int = 15) -> ActivityDetails:
+    """Return a timed activity (howLongInMins > 0)."""
+    return ActivityDetails(
+        description="Naprawa serwera",
+        who="Jan Kowalski",
+        when=ActivityDate(year=2024, month=6, day=15),
+        how_long_in_mins=mins,
+        how_far_in_kms=kms,
+    )
+
+
+def _make_untimed_activity(kms: int = 10) -> ActivityDetails:
+    """Return an untimed / extra-service activity (howLongInMins == 0)."""
+    return ActivityDetails(
+        description="Konsultacja telefoniczna",
+        who="Anna Nowak",
+        when=ActivityDate(year=2024, month=6, day=16),
+        how_long_in_mins=0,
+        how_far_in_kms=kms,
+    )
+
+
+def _extract_pdf_text(pdf_bytes: bytes) -> str:
+    """Extract readable text from a PDF by decoding its content streams.
+
+    ReportLab encodes streams with ASCII85Decode + FlateDecode by default.
+    This helper iterates over every stream, attempts ASCII85 + zlib decoding,
+    and falls back to raw latin-1 for any stream that cannot be decoded.
+    """
+    raw_streams = re.findall(b"stream\r?\n(.+?)endstream", pdf_bytes, re.DOTALL)
+    parts: list[str] = []
+    for raw in raw_streams:
+        text = ""
+        # Try ASCII85 → zlib (ReportLab default)
+        try:
+            a85_decoded = base64.a85decode(raw, adobe=True)
+            text = zlib.decompress(a85_decoded).decode("latin-1", errors="replace")
+        except Exception:
+            pass
+        # Try plain zlib (compress=0 or older builds)
+        if not text:
+            try:
+                text = zlib.decompress(raw).decode("latin-1", errors="replace")
+            except Exception:
+                text = raw.decode("latin-1", errors="replace")
+        parts.append(text)
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_generate_pdf_returns_bytes() -> None:
+    """generate_pdf returns non-empty bytes with a valid PDF signature."""
+    request = ReportRequest(
+        customer=_make_customer(),
+        activities=[
+            _make_timed_activity(),
+            _make_timed_activity(mins=60, kms=5),
+            _make_untimed_activity(),
+        ],
+    )
+
+    result = generate_pdf(request)
+
+    assert isinstance(result, bytes)
+    assert result[:4] == b"%PDF", "Must start with PDF magic bytes"
+    assert len(result) > 100
+
+
+def test_generate_pdf_contains_customer_name() -> None:
+    """Generated PDF contains the customer name in its content stream."""
+    customer_name = "Test Firma"
+    request = ReportRequest(
+        customer=_make_customer(customer_name),
+        activities=[_make_timed_activity()],
+    )
+
+    result = generate_pdf(request)
+    content_str = _extract_pdf_text(result)
+
+    assert customer_name in content_str
+
+
+def test_generate_pdf_empty_activities() -> None:
+    """generate_pdf handles a request with zero activities without raising."""
+    request = ReportRequest(
+        customer=_make_customer(),
+        activities=[],
+    )
+
+    result = generate_pdf(request)
+
+    assert isinstance(result, bytes)
+    assert result[:4] == b"%PDF"
+
+
+def test_generate_pdf_timed_activity_appears() -> None:
+    """Duration '1:30' and distance '15' appear in the PDF for a 90-min/15-km activity."""
+    request = ReportRequest(
+        customer=_make_customer(),
+        activities=[_make_timed_activity(mins=90, kms=15)],
+    )
+
+    result = generate_pdf(request)
+    content_str = _extract_pdf_text(result)
+
+    assert "1:30" in content_str
+    assert "15" in content_str
+
+
+def test_generate_pdf_untimed_activity_appears() -> None:
+    """'USŁUGI DODATKOWE' section is embedded for an untimed activity."""
+    request = ReportRequest(
+        customer=_make_customer(),
+        activities=[_make_untimed_activity()],
+    )
+
+    result = generate_pdf(request)
+    content_str = _extract_pdf_text(result)
+
+    # "USŁUGI DODATKOWE" — the ASCII portion "DODATKOWE" is safe to check
+    assert "DODATKOWE" in content_str

--- a/fun_report1/tests/test_zip_generator.py
+++ b/fun_report1/tests/test_zip_generator.py
@@ -1,0 +1,94 @@
+"""Unit tests for zip_generator.generate_zip.
+
+All tests are self-contained: they build in-memory ReportRequests objects,
+call generate_zip, and verify the returned bytes and ZIP structure without
+touching the file system or any external services.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+from src.models_report1 import ActivityDate, ActivityDetails, CustomerDetails, ReportRequest, ReportRequests
+from src.zip_generator import generate_zip
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(customer_name: str = "Acme Corp") -> ReportRequest:
+    """Return a minimal ReportRequest for *customer_name*."""
+    return ReportRequest(
+        customer=CustomerDetails(
+            customer_id="cust-001",
+            customer_name=customer_name,
+            customer_city="Kraków",
+            customer_address="Główna 5",
+        ),
+        activities=[
+            ActivityDetails(
+                description="Maintenance",
+                who="Jan Kowalski",
+                when=ActivityDate(year=2024, month=7, day=1),
+                how_long_in_mins=60,
+                how_far_in_kms=10,
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_generate_zip_returns_bytes() -> None:
+    """generate_zip returns bytes starting with the ZIP magic bytes 'PK'."""
+    requests = ReportRequests(items=[_make_request("Acme Corp"), _make_request("Beta Ltd")])
+
+    result = generate_zip(requests)
+
+    assert isinstance(result, bytes)
+    assert result[:2] == b"PK", "Must start with ZIP magic bytes"
+
+
+def test_generate_zip_contains_correct_files() -> None:
+    """ZIP contains correctly named files with slash-to-underscore sanitisation."""
+    requests = ReportRequests(
+        items=[
+            _make_request("Acme Corp"),
+            _make_request("Test/Co"),
+        ]
+    )
+
+    result = generate_zip(requests)
+
+    with zipfile.ZipFile(io.BytesIO(result)) as zf:
+        names = zf.namelist()
+
+    assert names == ["001-Acme Corp.pdf", "002-Test_Co.pdf"]
+
+
+def test_generate_zip_files_are_valid_pdfs() -> None:
+    """Each file extracted from the ZIP is a valid PDF (starts with %PDF)."""
+    requests = ReportRequests(items=[_make_request("Acme Corp")])
+
+    result = generate_zip(requests)
+
+    with zipfile.ZipFile(io.BytesIO(result)) as zf:
+        pdf_bytes = zf.read("001-Acme Corp.pdf")
+
+    assert pdf_bytes[:4] == b"%PDF"
+
+
+def test_generate_zip_empty_requests() -> None:
+    """generate_zip with zero items returns a valid, empty ZIP archive."""
+    requests = ReportRequests(items=[])
+
+    result = generate_zip(requests)
+
+    # Must be valid ZIP even when empty
+    with zipfile.ZipFile(io.BytesIO(result)) as zf:
+        assert zf.namelist() == []


### PR DESCRIPTION
Add a new endpoint to generate a PDF report for Report1, including updates to the OpenAPI schema to reflect the new request and response structures. This change enhances the reporting capabilities of the application.