### PR TITLE
Bump API version to 0.1.4

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,7 +37,7 @@ Services communicate through **Dapr sidecars**, not direct gRPC:
 ### Version Management Pattern
 **Three separate version files** with different formats:
 - `uservice-timeentries/.version` → `SEMVERSION` env var (e.g., "1.0.9")
-- `uservice-webapi/.semversion` → Maven `-Drevision` property (e.g., "0.1.3")
+- `uservice-webapi/.semversion` → Maven `-Drevision` property (e.g., "0.1.2")
 - `app-time/.version` → npm version (e.g., "1.4.3")
 
 Always use `$(cat .version)` pattern, never hardcode versions.

--- a/lib_api-java/.mvn/maven.config
+++ b/lib_api-java/.mvn/maven.config
@@ -1,1 +1,1 @@
--Drevision=0.1.3
+-Drevision=0.1.4

--- a/uservice-timeentries/base-pom/pom.xml
+++ b/uservice-timeentries/base-pom/pom.xml
@@ -7,7 +7,7 @@
 
   <properties>
     <spring-boot.version>3.5.10</spring-boot.version>
-    <api.version>0.1.3</api.version>
+    <api.version>0.1.4</api.version>
     <dapr.version>1.7.0</dapr.version>
     <guava.version>32.0.0-jre</guava.version>
     <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>

--- a/uservice-webapi/base-pom/pom.xml
+++ b/uservice-webapi/base-pom/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <spring-boot.version>3.5.11</spring-boot.version>
     <spring-modulith.version>1.4.8</spring-modulith.version>
-    <api.version>0.1.3</api.version>
+    <api.version>0.1.4</api.version>
     <!-- Disable warning
       [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent! -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Update the Maven configuration and related documentation to reflect the new API version 0.1.4. This change ensures consistency across version management files.