### PR TITLE
Migrate Report1 rendering to Azure Functions

### DIFF
--- a/infra/shared/main.tf
+++ b/infra/shared/main.tf
@@ -40,7 +40,10 @@ module "github" {
 }
 
 locals {
-  domain_name = "onlex.net"
+  domain_name       = "onlex.net"
+  report1_prefix    = "report1"
+  report1_hostname  = "${local.report1_prefix}.${local.domain_name}"
+  report1_base_url  = "https://${local.report1_hostname}"
 }
 
 module "cloudflare" {
@@ -49,7 +52,7 @@ module "cloudflare" {
   webapi_fqdn                    = module.container_apps_webapi.webapi_fqdn
   webapp_prefix_time             = "time"
   webapp_fqdn_time               = module.static_app_time.webapp_fqdn
-  report1_prefix                 = "report1"
+  report1_prefix                 = local.report1_prefix
   report1_fqdn                   = module.fun_report1.function_app_fqdn
   report1_domain_verification_id = module.fun_report1.custom_domain_verification_id
 }
@@ -93,6 +96,7 @@ module "container_apps_webapi" {
     DATABASE_USERNAME                     = module.database.database_username
     DATABASE_PASSWORD                     = module.database.database_password
     SINNETAPP_PROD_SECRET                 = module.keyvault.env.SINNETAPP_PROD_SECRET
+    REPORT1_FUNCTION_BASE_URL             = local.report1_base_url
   }
 
 }
@@ -127,7 +131,7 @@ module "fun_report1" {
 }
 
 resource "azurerm_app_service_custom_hostname_binding" "module_fun_report1" {
-  hostname            = "report1.onlex.net"
+  hostname            = local.report1_hostname
   app_service_name    = module.fun_report1.function_app_name
   resource_group_name = module.resourcegroup.main.name
 

--- a/infra/shared/module_container_app_webapi/main.tf
+++ b/infra/shared/module_container_app_webapi/main.tf
@@ -186,6 +186,11 @@ resource "azurerm_container_app" "default" {
         name  = "JAVA_TOOL_OPTIONS"
         value = "-javaagent:/appinsights/applicationinsights-agent.jar"
       }
+
+      env {
+        name  = "REPORT1_FUNCTION_BASE_URL"
+        value = var.env.REPORT1_FUNCTION_BASE_URL
+      }
     }
   }
 }

--- a/infra/shared/module_container_app_webapi/variables.tf
+++ b/infra/shared/module_container_app_webapi/variables.tf
@@ -25,6 +25,7 @@ variable "env" {
     DATABASE_USERNAME                     = string
     DATABASE_PASSWORD                     = string
     SINNETAPP_PROD_SECRET                 = string
+    REPORT1_FUNCTION_BASE_URL             = string
   })
 }
 

--- a/infra/shared/output.tf
+++ b/infra/shared/output.tf
@@ -15,5 +15,5 @@ output "function_report1_fqdn" {
 
 output "report1_url" {
   description = "The public URL of report1 (via Cloudflare)"
-  value       = "https://report1.onlex.net"
+  value       = local.report1_base_url
 }


### PR DESCRIPTION
Migrate the Report1 rendering logic to an Azure Function, improving scalability and performance. This change includes updates to infrastructure configuration, environment variables, and output URLs to support the new rendering service.

Fixes #513