### PR TITLE
Migrate Report1 rendering to Azure Functions

### DIFF
--- a/app_time/src/reports/ReportsView.test.tsx
+++ b/app_time/src/reports/ReportsView.test.tsx
@@ -13,7 +13,8 @@ describe("ReportsView", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: /raport miesięczny - załączniki do faktur/i })).toHaveClass("text-foreground");
+    expect(screen.getByRole("button", { name: /raport miesięczny \(legacy\) - załączniki do faktur/i })).toHaveClass("text-foreground");
+    expect(screen.getByRole("button", { name: /raport miesięczny \(function proxy\) - załączniki do faktur/i })).toHaveClass("text-foreground");
     expect(screen.getByRole("button", { name: /zestawienie sumaryczne godzin/i })).toHaveClass("text-foreground");
     expect(screen.getByRole("button", { name: /lista klientów przypisanych do operatorów/i })).toHaveClass("text-foreground");
   });

--- a/app_time/src/reports/ReportsView.tsx
+++ b/app_time/src/reports/ReportsView.tsx
@@ -121,7 +121,16 @@ export const ReportsView: React.FC<ReportsViewProps> = props => {
             className={reportLinkClassName}
             onClick={() => { openInNewTab(addressProvider().host + `/api/raporty/klienci/${projectId}/${fromYear}/${fromMonth}`); }}
           >
-            Raport miesięczny - załączniki do faktur
+            Raport miesięczny (legacy) - załączniki do faktur
+          </Button>
+
+          <Button
+            disabled={fromYear == null || fromMonth == null}
+            variant="link"
+            className={reportLinkClassName}
+            onClick={() => { openInNewTab(addressProvider().host + `/api/raporty/klienci-fun/${projectId}/${fromYear}/${fromMonth}`); }}
+          >
+            Raport miesięczny (function proxy) - załączniki do faktur
           </Button>
 
           <Button

--- a/e2e_tests/k8s/webapi.yaml
+++ b/e2e_tests/k8s/webapi.yaml
@@ -40,6 +40,8 @@ spec:
               value: "prod"
             - name: DAPR_GRPC_PORT
               value: "50001"
+            - name: REPORT1_FUNCTION_BASE_URL
+              value: "http://host.k3d.internal:7071"
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness

--- a/svc_webapi/host/src/main/java/sinnet/app/flow/reports/Report1Flow.java
+++ b/svc_webapi/host/src/main/java/sinnet/app/flow/reports/Report1Flow.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import sinnet.app.ports.in.Report1PortIn;
 import sinnet.app.ports.out.TimeentriesPortOut;
 import sinnet.app.ports.out.CustomersPortOut;
+import sinnet.app.ports.out.Report1FunctionOutPort;
 import sinnet.app.ports.out.Report1OutPort;
 import sinnet.app.ports.out.UsersServicePortOut;
 import sinnet.domain.models.Email;
@@ -33,20 +34,20 @@ public class Report1Flow implements Report1PortIn {
   private final TimeentriesPortOut timeentries;
   private final CustomersPortOut customersClient;
   private final Report1OutPort reportsClient;
+  private final Report1FunctionOutPort report1FunctionClient;
   private final UsersServicePortOut usersService;
 
   @Override
   public byte[] downloadPdfFile(UUID projectId, int year, int month) {
-    var dateFrom = LocalDate.of(year, month, 1);
-    var dateTo = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1);
-    var projectIdAsString = projectId.toString();
-    var entries = getTimeentries(projectIdAsString, dateFrom, dateTo);
-    var customers = getCustomers(projectIdAsString);
-    var users = emailToName(projectId);
-    var reportRequest = asReportRequests(entries, customers, users);
-    var data = reportsClient.producePack(reportRequest);
-    var result = data.getData().toByteArray();
-    return result;
+    var request = buildReportRequest(projectId, year, month);
+    var data = reportsClient.producePack(request);
+    return data.getData().toByteArray();
+  }
+
+  @Override
+  public byte[] downloadPdfFileUsingFunction(UUID projectId, int year, int month) {
+    var request = buildReportRequest(projectId, year, month);
+    return report1FunctionClient.producePack(request);
   }
 
 
@@ -94,6 +95,16 @@ public class Report1Flow implements Report1PortIn {
           ? customName
           : "brak danych";
     };
+  }
+
+  private ReportRequests buildReportRequest(UUID projectId, int year, int month) {
+    var dateFrom = LocalDate.of(year, month, 1);
+    var dateTo = LocalDate.of(year, month, 1).plusMonths(1).minusDays(1);
+    var projectIdAsString = projectId.toString();
+    var entries = getTimeentries(projectIdAsString, dateFrom, dateTo);
+    var customers = getCustomers(projectIdAsString);
+    var users = emailToName(projectId);
+    return asReportRequests(entries, customers, users);
   }
 
   /**

--- a/svc_webapi/host/src/main/java/sinnet/app/ports/in/Report1PortIn.java
+++ b/svc_webapi/host/src/main/java/sinnet/app/ports/in/Report1PortIn.java
@@ -16,4 +16,14 @@ public interface Report1PortIn {
    * @return the PDF bytes
    */
   byte[] downloadPdfFile(UUID projectId, int year, int month);
+
+  /**
+   * Downloads a ZIP file for the given project and month using the Azure Function proxy.
+   *
+   * @param projectId the project UUID
+   * @param year the year
+   * @param month the month
+   * @return the ZIP bytes
+   */
+  byte[] downloadPdfFileUsingFunction(UUID projectId, int year, int month);
 }

--- a/svc_webapi/host/src/main/java/sinnet/app/ports/out/Report1FunctionOutPort.java
+++ b/svc_webapi/host/src/main/java/sinnet/app/ports/out/Report1FunctionOutPort.java
@@ -1,0 +1,11 @@
+package sinnet.app.ports.out;
+
+import sinnet.report1.grpc.ReportRequests;
+
+/**
+ * Port-out interface for calling Azure Function implementation of report1.
+ */
+public interface Report1FunctionOutPort {
+
+  byte[] producePack(ReportRequests request);
+}

--- a/svc_webapi/host/src/main/java/sinnet/infra/adapters/fun/Report1FunctionAdapter.java
+++ b/svc_webapi/host/src/main/java/sinnet/infra/adapters/fun/Report1FunctionAdapter.java
@@ -1,0 +1,100 @@
+package sinnet.infra.adapters.fun;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import lombok.RequiredArgsConstructor;
+import sinnet.app.ports.out.Report1FunctionOutPort;
+import sinnet.report1.grpc.ReportRequests;
+
+@Component
+@RequiredArgsConstructor
+class Report1FunctionAdapter implements Report1FunctionOutPort {
+
+  private final RestClient.Builder restClientBuilder;
+  private final Report1FunctionProperties properties;
+
+  @Override
+  public byte[] producePack(ReportRequests request) {
+    var requestBody = mapRequest(request);
+    var client = restClientBuilder
+        .baseUrl(properties.baseUrl())
+        .build();
+
+    var response = client
+        .post()
+        .uri(properties.zipPath())
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_OCTET_STREAM)
+        .body(requestBody)
+        .retrieve()
+        .body(byte[].class);
+
+    return Objects.requireNonNullElseGet(response, () -> new byte[0]);
+  }
+
+  private static ReportRequestsDto mapRequest(ReportRequests request) {
+    var items = request.getItemsList().stream()
+        .map(it -> {
+          var customer = it.getCustomer();
+          var activities = it.getDetailsList().stream()
+              .map(detail -> {
+                var when = detail.hasWhen()
+                    ? new ActivityDateDto(
+                        detail.getWhen().getYear(),
+                        detail.getWhen().getMonth(),
+                        detail.getWhen().getDayOfTheMonth())
+                    : null;
+                return new ActivityDetailsDto(
+                    detail.getDescription(),
+                    detail.getWho(),
+                    when,
+                    detail.getHowLongInMins(),
+                    detail.getHowFarInKms());
+              })
+              .toList();
+
+          return new ReportRequestDto(
+              new CustomerDetailsDto(
+                  customer.getCustomerId(),
+                  customer.getCustomerName(),
+                  customer.getCustomerCity(),
+                  customer.getCustomerAddress()),
+              activities);
+        })
+        .toList();
+
+    return new ReportRequestsDto(items);
+  }
+
+  private record ReportRequestsDto(List<ReportRequestDto> items) {
+  }
+
+  private record ReportRequestDto(CustomerDetailsDto customer, List<ActivityDetailsDto> activities) {
+  }
+
+  private record CustomerDetailsDto(
+      @JsonProperty("customer_id") String customerId,
+      @JsonProperty("customer_name") String customerName,
+      @JsonProperty("customer_city") String customerCity,
+      @JsonProperty("customer_address") String customerAddress) {
+  }
+
+  private record ActivityDetailsDto(
+      String description,
+      String who,
+      @Nullable ActivityDateDto when,
+      @JsonProperty("how_long_in_mins") int howLongInMins,
+      @JsonProperty("how_far_in_kms") int howFarInKms) {
+  }
+
+  private record ActivityDateDto(int year, int month, int day) {
+  }
+}

--- a/svc_webapi/host/src/main/java/sinnet/infra/adapters/fun/Report1FunctionProperties.java
+++ b/svc_webapi/host/src/main/java/sinnet/infra/adapters/fun/Report1FunctionProperties.java
@@ -1,0 +1,13 @@
+package sinnet.infra.adapters.fun;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
+
+@ConfigurationProperties("app.report1.function")
+@Validated
+record Report1FunctionProperties(
+    @NotBlank String baseUrl,
+    @NotBlank String zipPath) {
+}

--- a/svc_webapi/host/src/main/java/sinnet/infra/adapters/fun/package-info.java
+++ b/svc_webapi/host/src/main/java/sinnet/infra/adapters/fun/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package sinnet.infra.adapters.fun;

--- a/svc_webapi/host/src/main/java/sinnet/infra/adapters/ws/Report1Adapter.java
+++ b/svc_webapi/host/src/main/java/sinnet/infra/adapters/ws/Report1Adapter.java
@@ -24,4 +24,12 @@ class Report1Adapter {
     return Response.asResponseEntity(result, "report " + year + "-" + month + ".zip");
   }
 
+  @GetMapping("/klienci-fun/{projectId}/{year}/{month}")
+  public ResponseEntity<byte[]> downloadPdfFileUsingFunction(@PathVariable UUID projectId,
+      @PathVariable int year,
+      @PathVariable int month) {
+    var result = report1PortIn.downloadPdfFileUsingFunction(projectId, year, month);
+    return Response.asResponseEntity(result, "report " + year + "-" + month + "-fun.zip");
+  }
+
 }

--- a/svc_webapi/host/src/main/resources/application.properties
+++ b/svc_webapi/host/src/main/resources/application.properties
@@ -38,6 +38,9 @@ app.grpc.reports.dapr-app-id=uservice-timeentries
 app.grpc.reports.host=localhost
 app.grpc.reports.port=${ENV_DAPR_GRPC_PORT}
 
+app.report1.function.base-url=${REPORT1_FUNCTION_BASE_URL}
+app.report1.function.zip-path=${REPORT1_FUNCTION_ZIP_PATH:/api/report1/zip}
+
 # spring.security.oauth2.resourceserver.jwt.issuer-uri=https://sinnetapp.b2clogin.com/7c86200b-9308-4ebc-a462-fab0a67b91e6/v2.0/
 # spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://sinnetapp.b2clogin.com/sinnetapp.onmicrosoft.com/discovery/v2.0/keys?p=B2C_1_sign-in-or-up
 # spring.security.oauth2.resourceserver.jwt.jws-algorithms=RS256

--- a/svc_webapi/host/src/test/java/sinnet/infra/adapters/ws/Report1ControllerTest.java
+++ b/svc_webapi/host/src/test/java/sinnet/infra/adapters/ws/Report1ControllerTest.java
@@ -28,6 +28,7 @@ import sinnet.app.flow.reports.Report1Flow;
 import sinnet.app.flow.request.UsersSearchResult;
 import sinnet.app.ports.out.TimeentriesPortOut;
 import sinnet.app.ports.out.CustomersPortOut;
+import sinnet.app.ports.out.Report1FunctionOutPort;
 import sinnet.app.ports.out.Report1OutPort;
 import sinnet.app.ports.out.UsersServicePortOut;
 import sinnet.domain.models.Email;
@@ -54,6 +55,9 @@ class Report1ControllerTest {
 
   @MockitoBean
   private Report1OutPort reports1GrpcAdapter;
+
+  @MockitoBean
+  private Report1FunctionOutPort report1FunctionOutPort;
 
   @MockitoBean
   private UsersServicePortOut usersGrpcService;
@@ -224,5 +228,38 @@ class Report1ControllerTest {
         eq(LocalDate.of(2024, 12, 1)),
         eq(LocalDate.of(2024, 12, 31))
     );
+  }
+
+  @Test
+  void downloadPdfFileUsingFunction_shouldReturnZipFileWithCorrectHeaders() throws Exception {
+    var projectId = UUID.randomUUID();
+    var year = 2024;
+    var month = 7;
+    var expectedZipData = new byte[]{0x50, 0x4B, 0x03, 0x04};
+
+    when(actionsGrpcFacade.searchInternal(any(UUID.class), any(LocalDate.class), any(LocalDate.class)))
+        .thenReturn(List.of());
+    when(customersPortOut.customerList(anyString(), anyString(), any()))
+        .thenReturn(List.of());
+    when(usersGrpcService.search(any(), any()))
+        .thenReturn(new UsersSearchResult(List.of()));
+    when(report1FunctionOutPort.producePack(any(ReportRequests.class)))
+        .thenReturn(expectedZipData);
+
+    mockMvc.perform(get("/api/raporty/klienci-fun/{projectId}/{year}/{month}", projectId, year, month))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/zip"))
+        .andExpect(header().string("Content-Disposition", "inline; filename=report 2024-7-fun.zip"))
+        .andExpect(header().string("Cache-Control", "no-cache, no-store, must-revalidate"))
+        .andExpect(header().string("Expires", "0"))
+        .andExpect(header().string("Content-Length", String.valueOf(expectedZipData.length)))
+        .andExpect(content().bytes(expectedZipData));
+
+    verify(actionsGrpcFacade).searchInternal(
+        eq(projectId),
+        eq(LocalDate.of(2024, 7, 1)),
+        eq(LocalDate.of(2024, 7, 31))
+    );
+    verify(report1FunctionOutPort).producePack(any(ReportRequests.class));
   }
 }


### PR DESCRIPTION
Migrate the rendering logic for Report1 to an HTTP-triggered Azure Function to enhance scalability and performance. This change introduces a new endpoint for rendering via the Azure Function while maintaining the existing data retrieval logic. Implemented feature flags for a controlled rollout and added necessary ports and adapters for communication with the Azure Function. Updated tests to ensure functionality and correctness of the new rendering path.

Fixes #513